### PR TITLE
Bump steno to latest git revision

### DIFF
--- a/stenographer/stenographer.spec
+++ b/stenographer/stenographer.spec
@@ -9,7 +9,7 @@
 Name:           stenographer
 Version:        0
 Release:        2.%{builddate}git%{shortcommit0}%{?dist}
-Epoch:          2
+Epoch:          1
 Summary:        A high-speed packet capture solution that provides indexed access
 
 License:        Apache License, 2.0
@@ -118,4 +118,3 @@ exit 0
 - Added datestamp to allow for proper RPM progression
 - Minor cleanups in SPEC file
 - Added systemd as build-time dependency
-

--- a/stenographer/stenographer.spec
+++ b/stenographer/stenographer.spec
@@ -19,6 +19,7 @@ Source0:        https://github.com/google/%{name}/archive/%{commit0}.tar.gz#/%{n
 BuildRequires:  libaio-devel, leveldb-devel, snappy-devel, gcc-c++, make
 BuildRequires:  libpcap-devel, libseccomp-devel, git
 BuildRequires:  golang
+BuildRequires:  rsync
 
 
 Requires:       libaio, leveldb, snappy, libpcap, libseccomp


### PR DESCRIPTION
Also cleans up go dependency imports and fixes warning about build ID