### PR TITLE
Spec fixes

### DIFF
--- a/binpac/binpac.spec
+++ b/binpac/binpac.spec
@@ -7,7 +7,7 @@ Summary:        High level language for describing protocol parsers.
 License:        BSD
 URL:            https://github.com/zeek/binpac
 Source0:        https://www.zeek.org/downloads/%{name}-%{version}.tar.gz
-Patch0:         https://github.com/zeek/binpac/compare/master...dcode:dcode/multiarch.patch#/patch0-use-cmake-std-install-vars.patch
+Patch0:         https://github.com/dcode/binpac/commit/5ffea9d9ba2f1b04b3cdc11225eea71ee41894a5.patch#/patch0-use-cmake-std-install-vars.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  cmake >= 2.8.3

--- a/bro-plugin-af_packet/bro-plugin-af_packet.spec
+++ b/bro-plugin-af_packet/bro-plugin-af_packet.spec
@@ -61,7 +61,7 @@ make %{?_smp_mflags}
 %dir %{_libdir}/bro/plugins/Bro_AF_Packet/scripts
 
 %{_libdir}/bro/plugins/Bro_AF_Packet/__bro_plugin__
-%{_libdir}/bro/plugins/Bro_AF_Packet/broctl/af_packet.py
+%{_libdir}/bro/plugins/Bro_AF_Packet/broctl/af_packet.p*
 %{_libdir}/bro/plugins/Bro_AF_Packet/lib/Bro-AF_Packet.linux-x86_64.so
 %{_libdir}/bro/plugins/Bro_AF_Packet/lib/bif/*.bro
 %{_libdir}/bro/plugins/Bro_AF_Packet/scripts/*.bro

--- a/bro/bro.spec
+++ b/bro/bro.spec
@@ -12,6 +12,7 @@ Provides:         zeek
 Requires:         bro-core = %{version}-%{release}
 
 Requires:         broctl = 1:1.9
+Requires:         bro-aux = 1:0.42
 BuildRequires:    cmake >= 2.8.12
 
 %description
@@ -33,7 +34,7 @@ Requires:         caf
 BuildRequires:    caf-devel
 Requires:         bind-libs
 BuildRequires:    bind-devel
-Requires:         libmaxminddb
+Requires:         libmaxminddb0
 BuildRequires:    libmaxminddb-devel
 %ifnarch s390 s390x
 Requires:         gperftools-libs

--- a/broctl/broctl.spec
+++ b/broctl/broctl.spec
@@ -12,6 +12,7 @@ Source1:        bro.service
 BuildRequires:  cmake >= 2.6.3
 BuildRequires:  gcc-c++
 BuildRequires:  python2-devel
+BuildRequires:  python-rpm-macros
 BuildRequires:  capstats >= 0.26
 BuildRequires:  trace-summary >= 0.88
 BuildRequires:  systemd

--- a/libmaxmind/libmaxminddb.spec
+++ b/libmaxmind/libmaxminddb.spec
@@ -27,7 +27,7 @@ Source:         https://github.com/maxmind/libmaxminddb/releases/download/%{vers
 Url:            http://dev.maxmind.com/
 BuildRequires:  fdupes
 BuildRequires:  gcc-c++
-BuildRequires:  pkg-config
+BuildRequires:  pkgconfig
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description


### PR DESCRIPTION
I ran into a few problems while using these spec files, the github url for the Patch on binpac is no longer valid, so I've updated the URL to one that still works.

For broctl, the line `%py_byte_compile %{__python2} %{buildroot}%{py_sitedir}` was erroring because the `py_byte_compile` macro was missing. I found that micro was included in python-rpm-macros.

When building Bro_AF_Packet I ran into 
```
error: Installed (but unpackaged) file(s) found:
   /usr/lib64/bro/plugins/Bro_AF_Packet/broctl/af_packet.pyc
   /usr/lib64/bro/plugins/Bro_AF_Packet/broctl/af_packet.pyo
```
so I have added those two files to be packaged as well.