### PR TITLE
Updates to build scripts

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,9 +4,8 @@ YUM := $(shell command -v yum 2> /dev/null)
 endif
 
 srpm:
-	cd $(outdir); \
-	cp $(spec) ./ ; \
 	$(YUM) -y install rpm-build rpmdevtools; \
-	spectool -A -g $(spec); \
+	spectool -A -g $(spec) -C $(shell dirname $(spec)); \
+	cd $(shell dirname $(spec)); \
 	chown root:root *; \
 	rpmbuild -bs -D '_sourcedir .' -D "_srcrpmdir $(outdir)" *.spec

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ srpm: $(outdir)/$(SRPM)
 
 rpm: $(outdir)/$(SRPM)
 	mock -r rock-7-x86_64.cfg --resultdir=$(outdir) $(outdir)/$(SRPM) --no-cleanup-after
+	createrepo_c --update $(outdir)
 
 copr: $(outdir)/$(SRPM)
 	copr-cli build -r epel-7-x86_64 @rocknsm/testing $(outdir)/$(SRPM)

--- a/rock-7-x86_64.cfg
+++ b/rock-7-x86_64.cfg
@@ -79,6 +79,11 @@ enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=x86_64
 failovermethod=priority
 
+[vagrant]
+name=vagrant
+baseurl=file:///vagrant/output
+cost=500
+enabled=1
 
 [local]
 name=local


### PR DESCRIPTION
- Adds createrepo post RPM build for when building with Vagrant
- Adds local repo on disk to mock's build config
- Makes copr Makefile more generic for working with more packages